### PR TITLE
fix parse input without type attribute

### DIFF
--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -8,7 +8,7 @@ WebMock.stub(:get, "example.com/check_form").to_return(body: <<-BODY
   <body>
     <form action="post_path" method="post" name="sample_form">
       <!-- fields -->
-      <input type="text" name="name">
+      <input name="name">
       <input type="text" name="email">
       <input type="hidden" name="userid" value="12345">
       <input type="password" id="pass" name="password">

--- a/src/mechanize/form.cr
+++ b/src/mechanize/form.cr
@@ -65,7 +65,7 @@ class MechanizeCr::Form
   private def parse
     @node.css("input").not_nil!.each do |html_node|
       html_node = html_node.as(Lexbor::Node)
-      type = (html_node["type"] || "text").downcase
+      type = (html_node["type"]? || "text").downcase
       case type
       when "checkbox"
         checkboxes << FormContent::CheckBox.new(html_node, self)


### PR DESCRIPTION
Fixes `Unhandled exception: Missing hash key: "type" (KeyError)`