### PR TITLE
add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ This method is from [lexbor](https://github.com/kostya/lexbor), so if you want t
 puts page.css("h1").first.inner_text
 ```
 
+### Logging
+
+For activation, simply setup the log to `:debug` level
+
+```crystal
+Log.setup("mechanize", :debug)
+```
+
 ## Contributing
 
 1. Fork it (<https://github.com/Kanezoh/mechanize.cr/fork>)

--- a/spec/log_spec.cr
+++ b/spec/log_spec.cr
@@ -1,0 +1,18 @@
+require "./spec_helper"
+require "log/spec"
+
+describe "Mechanize logging" do
+  it "emit logs" do
+    Log.capture("mechanize") do |logs|
+      agent = Mechanize.new
+      agent.user_agent = "Firefox"
+      page = agent.get("http://example.com/form")
+
+      logs.check(:debug, "GET: http://example.com/form")
+      logs.check(:debug, "request-header: User-Agent => Firefox")
+      logs.check(:debug, "status: HTTP/1.1 200 OK")
+      logs.check(:debug, "response-header: Content-length => 291")
+      logs.check(:debug, "response-header: Connection => close")
+    end
+  end
+end

--- a/src/mechanize.cr
+++ b/src/mechanize.cr
@@ -1,3 +1,4 @@
+require "log"
 require "uri"
 require "http/client"
 require "lexbor"
@@ -32,6 +33,7 @@ require "./mechanize/errors/*"
 # ```
 class Mechanize
   VERSION = "0.2.0"
+  Log     = ::Log.for(self)
 
   USER_AGENT = {
     "Mechanize" => "Mechanize/#{VERSION} Crystal/#{Crystal::VERSION} (https://github.com/Kanezoh/mechanize.cr)",
@@ -250,6 +252,9 @@ class Mechanize
     cur_page = form.page || (current_page unless history.empty?)
 
     request_data = form.request_data
+
+    Log.debug { "query: #{request_data.inspect}" }
+
     content_headers = ::HTTP::Headers{
       "Content-Type"   => form.enctype,
       "Content-Length" => request_data.size.to_s,


### PR DESCRIPTION
This implementation tries to mimic Ruby's `mechanize` logs. 

Logging:

- [x] Request method and URL
- [x] Request headers
- [x] Request  query on form submit
- [x] Response status 
- [x] Response headers
- [x] Saved cookies
- [x] Follow redirect to 

## Example    

```crystal
# https://httpbingo.org/

require "../src/mechanize"

Log.setup("mechanize", :debug)

agent = Mechanize.new
agent.user_agent = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0"

# Set cookies
page = agent.get("https://httpbingo.org/cookies/set?foo=bar")

# Get a page with redirect
params = URI::Params.encode({"url" => "https://httpbingo.org/forms/post"})
page = agent.get("https://httpbingo.org/redirect-to?#{params}")

# Submit a form
form = page.forms.first

time = Time.local + 5.minutes
time_s = time.to_s("%H:%N")

form.field_with("custname").value = "John Doe"
form.field_with("custtel").value = "user@example.com"
form.field_with("custemail").value = "+1 201-555-1234"
form.field_with("delivery").value = time_s
form.field_with("comments").value = "Delivery instructions"

if size_radiobuttons = form.radiobuttons_with("size")
  size_radiobuttons.find { |f| f.value == "medium" }.try(&.check)
end

if topping_checkboxes = form.checkboxes_with("topping")
  topping_checkboxes.select { |f| ["bacon", "cheese"].includes?(f.value) }.each(&.check)
end

agent.submit(form)
```

Output:

```
2021-11-18T07:53:22.572456Z  DEBUG - mechanize: GET: https://httpbingo.org/cookies/set?foo=bar
2021-11-18T07:53:22.572463Z  DEBUG - mechanize: request-header: User-Agent => Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0
2021-11-18T07:53:23.197392Z  DEBUG - mechanize: status: HTTP/1.1 302 Found
2021-11-18T07:53:23.197407Z  DEBUG - mechanize: response-header: access-control-allow-credentials => true
2021-11-18T07:53:23.197412Z  DEBUG - mechanize: response-header: access-control-allow-origin => *
2021-11-18T07:53:23.197416Z  DEBUG - mechanize: response-header: location => /cookies
2021-11-18T07:53:23.197420Z  DEBUG - mechanize: response-header: set-cookie => foo=bar; HttpOnly
2021-11-18T07:53:23.197423Z  DEBUG - mechanize: response-header: date => Thu, 18 Nov 2021 07:53:23 GMT
2021-11-18T07:53:23.197425Z  DEBUG - mechanize: response-header: server => Fly/e4851e2 (2021-11-04)
2021-11-18T07:53:23.197429Z  DEBUG - mechanize: response-header: via => 1.1 fly.io
2021-11-18T07:53:23.197432Z  DEBUG - mechanize: response-header: fly-request-id => 01FMS0JCPJVJZTB3RTPQNG4NNF
2021-11-18T07:53:23.197436Z  DEBUG - mechanize: response-header: content-length => 0
2021-11-18T07:53:23.197648Z  DEBUG - mechanize: saved cookie: foo=bar
2021-11-18T07:53:23.197815Z  DEBUG - mechanize: follow redirect to: https://httpbingo.org/cookies
2021-11-18T07:53:23.197869Z  DEBUG - mechanize: GET: https://httpbingo.org/cookies
2021-11-18T07:53:23.197876Z  DEBUG - mechanize: request-header: User-Agent => Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0
2021-11-18T07:53:23.197881Z  DEBUG - mechanize: request-header: Connection => close
2021-11-18T07:53:23.197885Z  DEBUG - mechanize: request-header: Cookie => foo=bar
2021-11-18T07:53:23.536472Z  DEBUG - mechanize: status: HTTP/1.1 200 OK
2021-11-18T07:53:23.536493Z  DEBUG - mechanize: response-header: access-control-allow-credentials => true
2021-11-18T07:53:23.536499Z  DEBUG - mechanize: response-header: access-control-allow-origin => *
2021-11-18T07:53:23.536503Z  DEBUG - mechanize: response-header: content-type => application/json; encoding=utf-8
2021-11-18T07:53:23.536506Z  DEBUG - mechanize: response-header: date => Thu, 18 Nov 2021 07:53:23 GMT
2021-11-18T07:53:23.536510Z  DEBUG - mechanize: response-header: transfer-encoding => chunked
2021-11-18T07:53:23.536513Z  DEBUG - mechanize: response-header: server => Fly/e4851e2 (2021-11-04)
2021-11-18T07:53:23.536516Z  DEBUG - mechanize: response-header: via => 1.1 fly.io
2021-11-18T07:53:23.536519Z  DEBUG - mechanize: response-header: fly-request-id => 01FMS0JD13SG448311ZX1M20QE
2021-11-18T07:53:23.536821Z  DEBUG - mechanize: GET: https://httpbingo.org/redirect-to?url=https%3A%2F%2Fhttpbingo.org%2Fforms%2Fpost
2021-11-18T07:53:23.536830Z  DEBUG - mechanize: request-header: User-Agent => Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0
2021-11-18T07:53:23.536834Z  DEBUG - mechanize: request-header: Connection => close
2021-11-18T07:53:23.536838Z  DEBUG - mechanize: request-header: Cookie => foo=bar
2021-11-18T07:53:23.536840Z  DEBUG - mechanize: request-header: Referer => https://httpbingo.org/cookies
2021-11-18T07:53:23.772936Z  DEBUG - mechanize: status: HTTP/1.1 302 Found
2021-11-18T07:53:23.772951Z  DEBUG - mechanize: response-header: access-control-allow-credentials => true
2021-11-18T07:53:23.772957Z  DEBUG - mechanize: response-header: access-control-allow-origin => *
2021-11-18T07:53:23.772960Z  DEBUG - mechanize: response-header: location => https://httpbingo.org/forms/post
2021-11-18T07:53:23.772963Z  DEBUG - mechanize: response-header: date => Thu, 18 Nov 2021 07:53:24 GMT
2021-11-18T07:53:23.772966Z  DEBUG - mechanize: response-header: server => Fly/e4851e2 (2021-11-04)
2021-11-18T07:53:23.772969Z  DEBUG - mechanize: response-header: via => 1.1 fly.io
2021-11-18T07:53:23.772973Z  DEBUG - mechanize: response-header: fly-request-id => 01FMS0JD8EH5X90BHSX0DCBRG7
2021-11-18T07:53:23.773012Z  DEBUG - mechanize: response-header: content-length => 0
2021-11-18T07:53:23.773257Z  DEBUG - mechanize: follow redirect to: https://httpbingo.org/forms/post
2021-11-18T07:53:23.773334Z  DEBUG - mechanize: GET: https://httpbingo.org/forms/post
2021-11-18T07:53:23.773342Z  DEBUG - mechanize: request-header: User-Agent => Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0
2021-11-18T07:53:23.773346Z  DEBUG - mechanize: request-header: Connection => close
2021-11-18T07:53:23.773350Z  DEBUG - mechanize: request-header: Referer => https://httpbingo.org/cookies
2021-11-18T07:53:23.773353Z  DEBUG - mechanize: request-header: Cookie => foo=bar
2021-11-18T07:53:24.003496Z  DEBUG - mechanize: status: HTTP/1.1 200 OK
2021-11-18T07:53:24.003506Z  DEBUG - mechanize: response-header: access-control-allow-credentials => true
2021-11-18T07:53:24.003510Z  DEBUG - mechanize: response-header: access-control-allow-origin => *
2021-11-18T07:53:24.003512Z  DEBUG - mechanize: response-header: content-type => text/html; charset=utf-8
2021-11-18T07:53:24.003514Z  DEBUG - mechanize: response-header: date => Thu, 18 Nov 2021 07:53:24 GMT
2021-11-18T07:53:24.003516Z  DEBUG - mechanize: response-header: transfer-encoding => chunked
2021-11-18T07:53:24.003517Z  DEBUG - mechanize: response-header: server => Fly/e4851e2 (2021-11-04)
2021-11-18T07:53:24.003519Z  DEBUG - mechanize: response-header: via => 1.1 fly.io
2021-11-18T07:53:24.003521Z  DEBUG - mechanize: response-header: fly-request-id => 01FMS0JDFS4680CXG5W8SK0DJZ
2021-11-18T07:53:24.005548Z  DEBUG - mechanize: query: "custname=John+Doe&custtel=user%40example.com&custemail=%2B1+201-555-1234&delivery=09%3A004312308&comments=Delivery+instructions&topping=bacon&topping=cheese&size=medium"
2021-11-18T07:53:24.005723Z  DEBUG - mechanize: POST: https://httpbingo.org/post
2021-11-18T07:53:24.005730Z  DEBUG - mechanize: request-header: User-Agent => Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0
2021-11-18T07:53:24.005733Z  DEBUG - mechanize: request-header: Connection => close
2021-11-18T07:53:24.005735Z  DEBUG - mechanize: request-header: Referer => https://httpbingo.org/forms/post
2021-11-18T07:53:24.005737Z  DEBUG - mechanize: request-header: Content-Type => application/x-www-form-urlencoded
2021-11-18T07:53:24.005739Z  DEBUG - mechanize: request-header: Content-Length => 168
2021-11-18T07:53:24.005741Z  DEBUG - mechanize: request-header: Cookie => foo=bar
2021-11-18T07:53:24.248473Z  DEBUG - mechanize: status: HTTP/1.1 200 OK
2021-11-18T07:53:24.248487Z  DEBUG - mechanize: response-header: access-control-allow-credentials => true
2021-11-18T07:53:24.248491Z  DEBUG - mechanize: response-header: access-control-allow-origin => *
2021-11-18T07:53:24.248494Z  DEBUG - mechanize: response-header: content-type => application/json; encoding=utf-8
2021-11-18T07:53:24.248497Z  DEBUG - mechanize: response-header: date => Thu, 18 Nov 2021 07:53:24 GMT
2021-11-18T07:53:24.248499Z  DEBUG - mechanize: response-header: transfer-encoding => chunked
2021-11-18T07:53:24.248509Z  DEBUG - mechanize: response-header: server => Fly/e4851e2 (2021-11-04)
2021-11-18T07:53:24.248511Z  DEBUG - mechanize: response-header: via => 1.1 fly.io
2021-11-18T07:53:24.248514Z  DEBUG - mechanize: response-header: fly-request-id => 01FMS0JDQ605ZVG3EBJ5DC7RW9

```