### PR TITLE
fix deprecation warning

### DIFF
--- a/src/mechanize/http/agent.cr
+++ b/src/mechanize/http/agent.cr
@@ -170,7 +170,11 @@ class Mechanize
           end
           # escape non-ascii character
           target_url = target_url.gsub(/[^#{0.chr}-#{126.chr}]/) { |match|
-            URI.encode(match)
+            {% if compare_versions(Crystal::VERSION, "1.1.1") > 0 %}
+              URI.encode_path(match)
+            {% else %}
+              URI.encode(match)
+            {% end %}
           }
           target_url = URI.parse(target_url)
         end


### PR DESCRIPTION
Fixes

```
In src/mechanize/http/agent.cr:173:17

 173 | URI.encode(match)
           ^-----
Warning: Deprecated URI.encode. Use `.encode_path` instead.

In /snap/crystal/971/share/crystal/src/uri/encoding.cr:119:25

 119 | String.build { |io| encode(string, io, space_to_plus: space_to_plus) }
                           ^-----
Warning: Deprecated URI.encode:space_to_plus. Use `.encode_path` instead.
```