### PR TITLE
fix set proxy issue

### DIFF
--- a/src/mechanize/http/agent.cr
+++ b/src/mechanize/http/agent.cr
@@ -45,7 +45,7 @@ class Mechanize
         uri, params = resolve_parameters(uri, method, params)
         client = ::HTTP::Client.new(uri)
         request_auth client, uri
-        client.set_proxy(@proxy) if @proxy
+        @proxy.try { |proxy| client.set_proxy(proxy) }
         response = http_request(client, uri, method, params, body)
         body = response.not_nil!.body
         page = response_parse(response, body, uri)

--- a/src/mechanize/http/agent.cr
+++ b/src/mechanize/http/agent.cr
@@ -45,7 +45,7 @@ class Mechanize
         uri, params = resolve_parameters(uri, method, params)
         client = ::HTTP::Client.new(uri)
         request_auth client, uri
-        @proxy.try { |proxy| client.set_proxy(proxy) }
+        @proxy.try { |proxy| client.proxy = proxy }
         response = http_request(client, uri, method, params, body)
         body = response.not_nil!.body
         page = response_parse(response, body, uri)


### PR DESCRIPTION
Fixes 

```
Showing last frame. Use --error-trace for full trace.

In src/mechanize/http/agent.cr:48:26

 48 | client.set_proxy(@proxy) if @proxy
                       ^-----
Error: expected argument #1 to 'HTTP::Client#set_proxy' to be HTTP::Proxy::Client, not (HTTP::Proxy::Client | Nil)

Overloads are:
 - HTTP::Client#set_proxy(proxy_client : HTTP::Proxy::Client)
```

https://github.com/mamantoha/vk_auth/actions/runs/8954517008/job/24594254489